### PR TITLE
Fix incorrect code in 1-3

### DIFF
--- a/learn/chapter1/3-element-buffer-objects.md
+++ b/learn/chapter1/3-element-buffer-objects.md
@@ -20,7 +20,7 @@ float[] vertices = {
 Then, below it, add the following array:
 
 ```cs
-uint indices[] = {  // note that we start from 0!
+uint[] indices = {  // note that we start from 0!
     0, 1, 3,   // first triangle
     1, 2, 3    // second triangle
 };


### PR DESCRIPTION
Copy-pasting trivial code from C++ ends in disaster.

`uint indices[]` has been changed to `uint[] indicies`.